### PR TITLE
Potential fix for code scanning alert no. 13: Database query built from user-controlled sources

### DIFF
--- a/api/controllers/payments.js
+++ b/api/controllers/payments.js
@@ -268,7 +268,7 @@ exports.payments_mpesa_callback = async (req, res) => {
 
         // Find payment by checkout request ID
         const payment = await Payment.findOne({
-            transactionId: result.checkoutRequestId
+            transactionId: { $eq: result.checkoutRequestId }
         });
 
         if (payment) {

--- a/api/services/mpesaService.js
+++ b/api/services/mpesaService.js
@@ -212,9 +212,28 @@ class MpesaService extends PaymentService {
      */
     async handleCallback(callbackData) {
         try {
+            if (
+                !callbackData ||
+                typeof callbackData !== 'object' ||
+                !callbackData.Body ||
+                typeof callbackData.Body !== 'object' ||
+                !callbackData.Body.stkCallback ||
+                typeof callbackData.Body.stkCallback !== 'object'
+            ) {
+                logError('Invalid M-Pesa callback structure', { callbackData });
+                throw new Error('Invalid M-Pesa callback structure');
+            }
+
             const body = callbackData.Body.stkCallback;
             const resultCode = body.ResultCode;
             const checkoutRequestId = body.CheckoutRequestID;
+
+            if (typeof checkoutRequestId !== 'string') {
+                logError('Invalid CheckoutRequestID type in M-Pesa callback', {
+                    checkoutRequestIdType: typeof checkoutRequestId
+                });
+                throw new Error('Invalid CheckoutRequestID in M-Pesa callback');
+            }
             
             logInfo('M-Pesa callback received', {
                 checkoutRequestId,


### PR DESCRIPTION
Potential fix for [https://github.com/Zoe-life/rest-shop/security/code-scanning/13](https://github.com/Zoe-life/rest-shop/security/code-scanning/13)

In general, to fix database queries built from user-controlled sources, you must ensure that any untrusted input used in a query is constrained to safe, expected types and values. For MongoDB/Mongoose, this typically means either (a) using the `$eq` operator so that the value is always treated as a literal and not as a query object, and/or (b) validating that the value is a primitive (e.g. string) and within allowed bounds before constructing the query.

For this specific case, the problematic part is:

```js
const payment = await Payment.findOne({
    transactionId: result.checkoutRequestId
});
```

where `result.checkoutRequestId` originates from `callbackData.Body.stkCallback.CheckoutRequestID` (user-controlled). The safest change without altering functionality is to (1) validate that `callbackData` has the expected M-Pesa structure and that `Body.stkCallback.CheckoutRequestID` is a string, and (2) use `$eq` when querying so that even if an attacker tries to send an object, it will be treated as a literal (or rejected by validation).

Concretely:

1. In `mpesaService.handleCallback`, add defensive checks so that if `callbackData.Body`, `callbackData.Body.stkCallback`, or its `CheckoutRequestID` are missing or not a string, you log an error and throw, preventing tainted non-primitive data from propagating.
2. In `payments_mpesa_callback` (api/controllers/payments.js), when querying for the payment, change the query to:

   ```js
   const payment = await Payment.findOne({
       transactionId: { $eq: result.checkoutRequestId }
   });
   ```

   This ensures Mongoose/Mongo interpret `checkoutRequestId` as a literal value, not as a query object.

These changes are minimal, keep the behavior the same for valid M-Pesa callbacks, and address the CodeQL warning by both validating structure and making the query injection-resistant.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
