### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -130,6 +130,22 @@ exports.user_signup = async (req, res, next) => {
  */
 exports.user_login = async (req, res, next) => {
     try {
+        const email = req.body && req.body.email;
+        if (typeof email !== 'string' || email.trim() === '') {
+            logAuthFailure({
+                email: email,
+                ipAddress: getClientIp(req),
+                userAgent: getUserAgent(req),
+                outcome: 'failure',
+                reason: 'Invalid email format'
+            });
+            return res.status(400).json({
+                message: 'Invalid credentials'
+            });
+        }
+        // normalize email to a trimmed string to avoid passing non-primitive values into the query
+        req.body.email = email.trim();
+
         const user = await User.find({ email: req.body.email }).exec();
         if (user.length < 1) {
             return res.status(401).json({
@@ -180,7 +196,7 @@ exports.user_login = async (req, res, next) => {
     } catch (err) {
         logError('User login error', err);
         logAuthFailure({
-            email: req.body.email,
+            email: req.body && req.body.email,
             ipAddress: getClientIp(req),
             userAgent: getUserAgent(req),
             outcome: 'failure',


### PR DESCRIPTION
Potential fix for [https://github.com/Zoe-life/rest-shop/security/code-scanning/2](https://github.com/Zoe-life/rest-shop/security/code-scanning/2)

In general, to fix NoSQL injection risks when building query objects from user-provided data, you must ensure that the untrusted value is interpreted strictly as a literal (for example, a string) and not as a query operator object. This can be done either by validating the type and shape of the data (for example, checking it is a string and not an object) before using it in a query, or by wrapping it in an operator like `$eq` so that MongoDB treats it as a literal value even if it is an object.

For this specific case in `api/controllers/user.js`, the cleanest fix that preserves existing functionality is to validate `req.body.email` and, if it is not a string, reject the login attempt with a `400 Bad Request` rather than sending it to MongoDB. We can implement a small runtime check at the start of `user_login`: ensure `typeof req.body.email === 'string'`, optionally trim it, and ensure it's non-empty; if the check fails, return a 400 with a generic error message. After that check, we can safely use `req.body.email` in `User.find({ email: req.body.email })`, because we know we are passing a primitive string, not a query object. This change only affects the `user_login` controller in this file (around line 131+), does not require any change to imports, and it keeps the existing logging and response behavior for valid requests.

Concretely:
- In `exports.user_login`, just after entering the `try` block (before calling `User.find`), add validation logic that:
  - Extracts `email` from `req.body`.
  - Confirms it is a string.
  - Optionally trims whitespace and reassigns it to `req.body.email` to keep later code working unchanged.
  - If the validation fails, logs an auth failure and returns `400` with a generic message.
- Leave the rest of the login logic intact.

This adds no new dependencies and keeps the controller behavior the same for well-formed requests while eliminating the possibility of a query object being injected via `req.body.email`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
