### PR TITLE
Potential fix for code scanning alert no. 5: CORS misconfiguration for credentials transfer

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,8 +32,10 @@ app.use((req, res, next) => {
         : ['http://localhost:3001'];
     
     const origin = req.headers.origin;
-    if (allowedOrigins.includes(origin) || !origin) {
-        res.setHeader('Access-Control-Allow-Origin', origin || '*');
+    // Never allow wildcard or null origins when credentials are enabled.
+    const isOriginAllowed = origin && origin !== 'null' && allowedOrigins.includes(origin);
+    if (isOriginAllowed) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
         res.setHeader('Access-Control-Allow-Credentials', 'true');
         res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
         res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');


### PR DESCRIPTION
Potential fix for [https://github.com/Zoe-life/rest-shop/security/code-scanning/5](https://github.com/Zoe-life/rest-shop/security/code-scanning/5)

In general, when `Access-Control-Allow-Credentials` is `"true"`, you must (1) never use `"*"` or `"null"` as `Access-Control-Allow-Origin`, and (2) only echo back an origin that has been validated against a safe, server-controlled whitelist. For requests without a valid origin you should either omit both CORS headers or respond with a controlled, static origin and no credentials.

Concretely for this file:

- Remove the use of `origin || '*'` so that you never send `*` when `Allow-Credentials` is `true`.
- Keep the whitelist logic but only set `Access-Control-Allow-Origin` when `origin` is present and in `allowedOrigins`.
- Optionally, for requests without an `Origin` header, do not set any CORS headers at all; they are not needed for same-origin requests and this avoids the misconfiguration.
- Ensure you never allow `null` as an allowed origin, even if misconfigured in `ALLOWED_ORIGINS` (a small runtime guard).

Changes needed in `app.js`:

1. Adjust the CORS middleware block (lines 28–43):
   - Compute `allowedOrigins` as before.
   - Add a guard that filters out `"null"` from the runtime whitelist.
   - Replace `if (allowedOrigins.includes(origin) || !origin) { ... }` with `if (origin && allowedOrigins.includes(origin)) { ... }`.
   - Inside that block, set `Access-Control-Allow-Origin` to `origin` only (no fallback to `*`), and keep `Access-Control-Allow-Credentials: 'true'`.
   - For requests with no `origin` header or an origin not in the whitelist, set no CORS headers (or at least do not set `Access-Control-Allow-Credentials` nor `Access-Control-Allow-Origin`).

No new imports or additional helper methods are required; the logic change is local to the middleware function in `app.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
